### PR TITLE
feat: add .env.example for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# =============================================================================
+# Portugal Road Watch - Environment Variables
+# =============================================================================
+# Copy this file to .env and fill in the values:
+#   cp .env.example .env
+# =============================================================================
+
+# ---------------------
+# Supabase (required)
+# ---------------------
+# Each contributor runs their own local Supabase instance.
+#
+# 1. Install the Supabase CLI: https://supabase.com/docs/guides/cli/getting-started
+# 2. Start the local instance (requires Docker):
+#      supabase start
+# 3. The CLI will output the API URL and anon key — paste them below.
+#
+# Example output from `supabase start`:
+#   API URL: http://127.0.0.1:54321
+#   anon key: eyJhbGciOiJI...
+#
+VITE_SUPABASE_URL=http://127.0.0.1:54321
+VITE_SUPABASE_PUBLISHABLE_KEY=your-local-anon-key
+
+# ---------------------
+# Geocoding (optional)
+# ---------------------
+# Geocoding provider used for reverse-geocoding pothole locations.
+# Currently supported: "nominatim" (default)
+# VITE_GEOCODING_PROVIDER=nominatim


### PR DESCRIPTION
## Summary

- Adds a `.env.example` file documenting all required and optional environment variables
- Guides contributors to use `supabase start` for a local-first development setup
- No shared Supabase instance needed — each contributor runs their own

Closes #1

## Test plan

- [ ] Clone the repo, copy `.env.example` to `.env`
- [ ] Run `supabase start` and paste the output credentials into `.env`
- [ ] Verify the app connects to the local Supabase instance