### PR TITLE
feat: add Dockerfile and docker-compose for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.git
+.idea
+.env
+*.log

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# =============================================================================
+# Portugal Road Watch - Environment Variables
+# =============================================================================
+# Copy this file to .env and fill in the values:
+#   cp .env.example .env
+# =============================================================================
+
+# ---------------------
+# Supabase (required)
+# ---------------------
+# Each contributor runs their own local Supabase instance.
+#
+# 1. Install the Supabase CLI: https://supabase.com/docs/guides/cli/getting-started
+# 2. Start the local instance (requires Docker):
+#      supabase start
+# 3. The CLI will output the API URL and anon key — paste them below.
+#
+# Example output from `supabase start`:
+#   API URL: http://127.0.0.1:54321
+#   anon key: eyJhbGciOiJI...
+#
+VITE_SUPABASE_URL=http://127.0.0.1:54321
+VITE_SUPABASE_PUBLISHABLE_KEY=your-local-anon-key
+
+# ---------------------
+# Geocoding (optional)
+# ---------------------
+# Geocoding provider used for reverse-geocoding pothole locations.
+# Currently supported: "nominatim" (default)
+# VITE_GEOCODING_PROVIDER=nominatim

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ dist-ssr
 *.sln
 *.sw?
 .env
+
+# Supabase local dev
+supabase/.branches
+supabase/.temp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -12,15 +12,50 @@ Aplicação web para reportar, visualizar e acompanhar buracos em estradas de Po
 
 ## Requisitos
 
+- Docker e Docker Compose
+- Supabase CLI — [instalar aqui](https://supabase.com/docs/guides/cli/getting-started)
+
+Ou, sem Docker:
+
 - Node.js 18+
 - npm 9+
-- Supabase CLI (opcional, para funções/migrations locais)
+- Supabase CLI
 
-## Setup local
+## Setup local (Docker — recomendado)
 
 ```sh
-git clone <URL_DO_REPOSITORIO>
+git clone https://github.com/wods-agency/portugal-road-watch.git
 cd portugal-road-watch
+cp .env.example .env
+
+# Inicia o Supabase local (base de dados, auth, storage)
+supabase start
+
+# Copia o API URL e anon key do output acima para o ficheiro .env
+
+# Inicia a aplicação
+docker compose up
+```
+
+App local: http://localhost:8080
+
+Para parar:
+
+```sh
+docker compose down
+supabase stop
+```
+
+## Setup local (sem Docker)
+
+```sh
+git clone https://github.com/wods-agency/portugal-road-watch.git
+cd portugal-road-watch
+cp .env.example .env
+
+supabase start
+# Copia o API URL e anon key para o .env
+
 npm install
 npm run dev
 ```
@@ -39,18 +74,13 @@ npm run lint
 
 ## Configuração de ambiente
 
-Criar um ficheiro .env com as variáveis necessárias do Supabase:
+Copiar `.env.example` para `.env` e preencher com os valores do `supabase start`:
 
 ```sh
-VITE_SUPABASE_URL=<url>
-VITE_SUPABASE_ANON_KEY=<anon_key>
+cp .env.example .env
 ```
 
-Opcional (geocoding):
-
-```sh
-VITE_GEOCODING_PROVIDER=nominatim
-```
+Ver `.env.example` para a lista completa de variáveis (obrigatórias e opcionais).
 
 ## Funcionalidades principais
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./src:/app/src
+      - ./public:/app/public
+      - ./index.html:/app/index.html
+    env_file:
+      - .env


### PR DESCRIPTION
## Summary

- Adds `Dockerfile` (Node 18 Alpine, runs Vite dev server)
- Adds `docker-compose.yml` with volume mounts for hot-reload (`src/`, `public/`, `index.html`)
- Adds `.dockerignore` to keep the image lean
- Includes `.env.example` from #1 so the setup is self-contained
- Updates `README.md` with Docker setup instructions (and keeps a non-Docker alternative)

### How it works

1. `supabase start` — spins up local Supabase (Postgres, Auth, Storage) and outputs credentials
2. `docker compose up` — builds and runs the frontend, picks up `.env` automatically

New contributors just need **Docker** and the **Supabase CLI** installed.

App running locally
<img width="1577" height="1079" alt="Screenshot 2026-02-16 at 22 38 37" src="https://github.com/user-attachments/assets/a8e9fa98-722c-4853-aae0-532c07e2320c" />


Closes #2

## Test plan

- [ ] Run `supabase start` and copy credentials to `.env`
- [ ] Run `docker compose up` and verify the app loads at http://localhost:8080
- [ ] Edit a file in `src/` and verify hot-reload works
- [ ] Run `docker compose down && supabase stop` to clean up